### PR TITLE
feat: add github action to send recently published slack message

### DIFF
--- a/.github/workflows/recently-published.yml
+++ b/.github/workflows/recently-published.yml
@@ -1,0 +1,33 @@
+name: Recently Published
+
+on:
+  schedule:
+    - cron: '0 14 * * MON'
+
+jobs:
+  recently-published:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Setup Node.JS
+        uses: actions/setup-node@v2
+        with:
+          node-version: '12'
+
+      - name: Install Dependencies
+        run: npm install --global @artsy/cli
+
+      - name: Run CLI
+        id: cli
+        run: echo "::set-output name=payload::$(artsy scheduled:recently-published)"
+        env:
+          SLACK_WEB_API_TOKEN: ${{ secrets.SLACK_WEB_API_TOKEN }}
+
+      - name: Standup Reminder > Slack
+        uses: 8398a7/action-slack@v3
+        with:
+          status: custom
+          custom_payload: ${{steps.cli.outputs.payload}}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Message defined in artsy/cli via https://github.com/artsy/cli/pull/64