### PR TITLE
feat: add facilitate incident review action

### DIFF
--- a/.github/workflows/facilitate-incident-review.yml
+++ b/.github/workflows/facilitate-incident-review.yml
@@ -1,0 +1,36 @@
+name: Facilitate Incident Review
+
+on:
+  schedule:
+    - cron: '0 14 * * WED'
+
+jobs:
+  facilitate-incident-review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Setup Node.JS
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Install Dependencies
+        run: npm install --global @artsy/cli
+
+      - name: Run CLI
+        id: cli
+        run: echo "PAYLOAD=$(artsy scheduled:facilitate-incident-review --facilitatorEmail=${{ secrets.EMAIL_OZ }} --useDatesVar)" >> $GITHUB_OUTPUT
+        env:
+          OPSGENIE_API_KEY: ${{ secrets.OPSGENIE_API_KEY }}
+          SLACK_WEB_API_TOKEN: ${{ secrets.SLACK_WEB_API_TOKEN }}
+          DATES: ${{ vars.DATES }}
+
+      - name: CLI payload > Slack
+        if: ${{ steps.cli.outputs.PAYLOAD != 'Off week' }}
+        uses: 8398a7/action-slack@v3
+        with:
+          status: custom
+          custom_payload: ${{ steps.cli.outputs.PAYLOAD }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
This PR adds a github action to run the recently added [facilitate-incident-review](https://github.com/artsy/cli/blob/main/src/commands/scheduled/facilitate-incident-review.ts) artsy cli command and on Incident Review weeks, post a message to slack.

The action is scheduled to run on each _Wed at 10AM ET (2PM UTC)_ and post to slack step will be skipped on _Off weeks_ for the Incident Review meeting. Example of [skipped run](https://github.com/artsy/joule/actions/runs/4895710894/jobs/8741628541) and a [successful run](https://github.com/artsy/joule/actions/runs/4895714907/jobs/8741636729).

The command depends on a [DATES GitHub actions variable](https://github.com/artsy/joule/settings/variables/actions) containing a starting date (`baseDate`) which is used to determine the _Off weeks_ for Incident Review.