### PR TITLE
chore: remove set-ouptut GHA workflow commands

### DIFF
--- a/.github/workflows/next-on-call.yml
+++ b/.github/workflows/next-on-call.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Run CLI
         id: cli
-        run: echo "::set-output name=payload::$(artsy scheduled:next-on-call)"
+        run: echo "PAYLOAD=$(artsy scheduled:next-on-call)" >> $GITHUB_OUTPUT
         env:
           OPSGENIE_API_KEY: ${{ secrets.OPSGENIE_API_KEY }}
           SLACK_WEB_API_TOKEN: ${{ secrets.SLACK_WEB_API_TOKEN }}
@@ -29,6 +29,6 @@ jobs:
         uses: 8398a7/action-slack@v3
         with:
           status: custom
-          custom_payload: ${{steps.cli.outputs.payload}}
+          custom_payload: ${{steps.cli.outputs.PAYLOAD}}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/open-rfcs.yml
+++ b/.github/workflows/open-rfcs.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Run CLI
         id: cli
-        run: echo "::set-output name=payload::$(artsy scheduled:rfcs)"
+        run: echo "PAYLOAD=$(artsy scheduled:rfcs)" >> $GITHUB_PAYLOAD
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 
@@ -28,6 +28,6 @@ jobs:
         uses: 8398a7/action-slack@v3
         with:
           status: custom
-          custom_payload: ${{steps.cli.outputs.payload}}
+          custom_payload: ${{steps.cli.outputs.PAYLOAD}}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/recently-published.yml
+++ b/.github/workflows/recently-published.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Run CLI
         id: cli
-        run: echo "::set-output name=payload::$(artsy scheduled:recently-published)"
+        run: echo "PAYLOAD=$(artsy scheduled:recently-published)" >> $GITHUB_PAYLOAD
         env:
           SLACK_WEB_API_TOKEN: ${{ secrets.SLACK_WEB_API_TOKEN }}
 
@@ -28,6 +28,6 @@ jobs:
         uses: 8398a7/action-slack@v3
         with:
           status: custom
-          custom_payload: ${{steps.cli.outputs.payload}}
+          custom_payload: ${{steps.cli.outputs.PAYLOAD}}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/standup-reminder.yml
+++ b/.github/workflows/standup-reminder.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Run CLI
         id: cli
-        run: echo "::set-output name=payload::$(artsy scheduled:standup-reminder)"
+        run: echo "PAYLOAD=$(artsy scheduled:standup-reminder)" >> $GITHUB_PAYLOAD
         env:
           OPSGENIE_API_KEY: ${{ secrets.OPSGENIE_API_KEY }}
           SLACK_WEB_API_TOKEN: ${{ secrets.SLACK_WEB_API_TOKEN }}
@@ -29,6 +29,6 @@ jobs:
         uses: 8398a7/action-slack@v3
         with:
           status: custom
-          custom_payload: ${{steps.cli.outputs.payload}}
+          custom_payload: ${{steps.cli.outputs.PAYLOAD}}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-5157

This PR removes `set-output` commands from GitHub actions and replaces those with `PAYLOAD` output parameter which is then stored in a [`$GITHUB_PAYLOAD` environment variable](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter) to be retrieved in the next step. This change is made to ensure uninterrupted runs as `set-output` has been [deprecated and is scheduled to be fully disabled on May 31st, 2023](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).