### PR TITLE
Revert "chore: remove set-ouptut GHA workflow commands"

### DIFF
--- a/.github/workflows/next-on-call.yml
+++ b/.github/workflows/next-on-call.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Run CLI
         id: cli
-        run: echo "PAYLOAD=$(artsy scheduled:next-on-call)" >> $GITHUB_OUTPUT
+        run: echo "::set-output name=payload::$(artsy scheduled:next-on-call)"
         env:
           OPSGENIE_API_KEY: ${{ secrets.OPSGENIE_API_KEY }}
           SLACK_WEB_API_TOKEN: ${{ secrets.SLACK_WEB_API_TOKEN }}
@@ -29,6 +29,6 @@ jobs:
         uses: 8398a7/action-slack@v3
         with:
           status: custom
-          custom_payload: ${{steps.cli.outputs.PAYLOAD}}
+          custom_payload: ${{steps.cli.outputs.payload}}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/open-rfcs.yml
+++ b/.github/workflows/open-rfcs.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Run CLI
         id: cli
-        run: echo "PAYLOAD=$(artsy scheduled:rfcs)" >> $GITHUB_PAYLOAD
+        run: echo "::set-output name=payload::$(artsy scheduled:rfcs)"
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 
@@ -28,6 +28,6 @@ jobs:
         uses: 8398a7/action-slack@v3
         with:
           status: custom
-          custom_payload: ${{steps.cli.outputs.PAYLOAD}}
+          custom_payload: ${{steps.cli.outputs.payload}}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/recently-published.yml
+++ b/.github/workflows/recently-published.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Run CLI
         id: cli
-        run: echo "PAYLOAD=$(artsy scheduled:recently-published)" >> $GITHUB_PAYLOAD
+        run: echo "::set-output name=payload::$(artsy scheduled:recently-published)"
         env:
           SLACK_WEB_API_TOKEN: ${{ secrets.SLACK_WEB_API_TOKEN }}
 
@@ -28,6 +28,6 @@ jobs:
         uses: 8398a7/action-slack@v3
         with:
           status: custom
-          custom_payload: ${{steps.cli.outputs.PAYLOAD}}
+          custom_payload: ${{steps.cli.outputs.payload}}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/standup-reminder.yml
+++ b/.github/workflows/standup-reminder.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Run CLI
         id: cli
-        run: echo "PAYLOAD=$(artsy scheduled:standup-reminder)" >> $GITHUB_PAYLOAD
+        run: echo "::set-output name=payload::$(artsy scheduled:standup-reminder)"
         env:
           OPSGENIE_API_KEY: ${{ secrets.OPSGENIE_API_KEY }}
           SLACK_WEB_API_TOKEN: ${{ secrets.SLACK_WEB_API_TOKEN }}
@@ -29,6 +29,6 @@ jobs:
         uses: 8398a7/action-slack@v3
         with:
           status: custom
-          custom_payload: ${{steps.cli.outputs.PAYLOAD}}
+          custom_payload: ${{steps.cli.outputs.payload}}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Going to revert artsy/joule#136 following some errors in [recent action runs](https://github.com/artsy/joule/actions/runs/5046754619/jobs/9052708475):

```
/home/runner/work/_temp/60db88fd-083e-4e69-9464-23843baf0095.sh: line 1: $GITHUB_PAYLOAD: ambiguous redirect
```

cc/ @ovasdi 