### PR TITLE
Revert 138 revert 136 ovasdi/platform 5157/remove set output

### DIFF
--- a/.github/workflows/facilitate-incident-review.yml
+++ b/.github/workflows/facilitate-incident-review.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Run CLI
         id: cli
-        run: echo "PAYLOAD=$(artsy scheduled:facilitate-incident-review --useDatesVar)" >> $GITHUB_OUTPUT
+        run: echo "PAYLOAD=$(artsy scheduled:facilitate-incident-review --useDatesVar)" >> "$GITHUB_OUTPUT"
         env:
           OPSGENIE_API_KEY: ${{ secrets.OPSGENIE_API_KEY }}
           SLACK_WEB_API_TOKEN: ${{ secrets.SLACK_WEB_API_TOKEN }}

--- a/.github/workflows/next-on-call.yml
+++ b/.github/workflows/next-on-call.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Run CLI
         id: cli
-        run: echo "PAYLOAD=$(artsy scheduled:next-on-call)" >> $GITHUB_OUTPUT
+        run: echo "PAYLOAD=$(artsy scheduled:next-on-call)" >> "$GITHUB_OUTPUT"
         env:
           OPSGENIE_API_KEY: ${{ secrets.OPSGENIE_API_KEY }}
           SLACK_WEB_API_TOKEN: ${{ secrets.SLACK_WEB_API_TOKEN }}

--- a/.github/workflows/next-on-call.yml
+++ b/.github/workflows/next-on-call.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Run CLI
         id: cli
-        run: echo "::set-output name=payload::$(artsy scheduled:next-on-call)"
+        run: echo "PAYLOAD=$(artsy scheduled:next-on-call)" >> $GITHUB_OUTPUT
         env:
           OPSGENIE_API_KEY: ${{ secrets.OPSGENIE_API_KEY }}
           SLACK_WEB_API_TOKEN: ${{ secrets.SLACK_WEB_API_TOKEN }}
@@ -30,6 +30,6 @@ jobs:
         uses: 8398a7/action-slack@v3
         with:
           status: custom
-          custom_payload: ${{steps.cli.outputs.payload}}
+          custom_payload: ${{steps.cli.outputs.PAYLOAD}}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/open-rfcs.yml
+++ b/.github/workflows/open-rfcs.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Run CLI
         id: cli
-        run: echo "PAYLOAD=$(artsy scheduled:rfcs)" >> $GITHUB_OUTPUT
+        run: echo "PAYLOAD=$(artsy scheduled:rfcs)" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 

--- a/.github/workflows/open-rfcs.yml
+++ b/.github/workflows/open-rfcs.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Run CLI
         id: cli
-        run: echo "::set-output name=payload::$(artsy scheduled:rfcs)"
+        run: echo "PAYLOAD=$(artsy scheduled:rfcs)" >> $GITHUB_PAYLOAD
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 
@@ -29,6 +29,6 @@ jobs:
         uses: 8398a7/action-slack@v3
         with:
           status: custom
-          custom_payload: ${{steps.cli.outputs.payload}}
+          custom_payload: ${{steps.cli.outputs.PAYLOAD}}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/open-rfcs.yml
+++ b/.github/workflows/open-rfcs.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Run CLI
         id: cli
-        run: echo "PAYLOAD=$(artsy scheduled:rfcs)" >> $GITHUB_PAYLOAD
+        run: echo "PAYLOAD=$(artsy scheduled:rfcs)" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 

--- a/.github/workflows/recently-published.yml
+++ b/.github/workflows/recently-published.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Run CLI
         id: cli
-        run: echo "::set-output name=payload::$(artsy scheduled:recently-published)"
+        run: echo "PAYLOAD=$(artsy scheduled:recently-published)" >> $GITHUB_PAYLOAD
         env:
           SLACK_WEB_API_TOKEN: ${{ secrets.SLACK_WEB_API_TOKEN }}
 
@@ -29,6 +29,6 @@ jobs:
         uses: 8398a7/action-slack@v3
         with:
           status: custom
-          custom_payload: ${{steps.cli.outputs.payload}}
+          custom_payload: ${{steps.cli.outputs.PAYLOAD}}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/recently-published.yml
+++ b/.github/workflows/recently-published.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Run CLI
         id: cli
-        run: echo "PAYLOAD=$(artsy scheduled:recently-published)" >> $GITHUB_PAYLOAD
+        run: echo "PAYLOAD=$(artsy scheduled:recently-published)" >> $GITHUB_OUTPUT
         env:
           SLACK_WEB_API_TOKEN: ${{ secrets.SLACK_WEB_API_TOKEN }}
 

--- a/.github/workflows/recently-published.yml
+++ b/.github/workflows/recently-published.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Run CLI
         id: cli
-        run: echo "PAYLOAD=$(artsy scheduled:recently-published)" >> $GITHUB_OUTPUT
+        run: echo "PAYLOAD=$(artsy scheduled:recently-published)" >> "$GITHUB_OUTPUT"
         env:
           SLACK_WEB_API_TOKEN: ${{ secrets.SLACK_WEB_API_TOKEN }}
 

--- a/.github/workflows/standup-reminder.yml
+++ b/.github/workflows/standup-reminder.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Run CLI
         id: cli
-        run: echo "::set-output name=payload::$(artsy scheduled:standup-reminder)"
+        run: echo "PAYLOAD=$(artsy scheduled:standup-reminder)" >> $GITHUB_PAYLOAD
         env:
           OPSGENIE_API_KEY: ${{ secrets.OPSGENIE_API_KEY }}
           SLACK_WEB_API_TOKEN: ${{ secrets.SLACK_WEB_API_TOKEN }}
@@ -30,6 +30,6 @@ jobs:
         uses: 8398a7/action-slack@v3
         with:
           status: custom
-          custom_payload: ${{steps.cli.outputs.payload}}
+          custom_payload: ${{steps.cli.outputs.PAYLOAD}}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/standup-reminder.yml
+++ b/.github/workflows/standup-reminder.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Run CLI
         id: cli
-        run: echo "PAYLOAD=$(artsy scheduled:standup-reminder)" >> $GITHUB_OUTPUT
+        run: echo "PAYLOAD=$(artsy scheduled:standup-reminder)" >> "$GITHUB_OUTPUT"
         env:
           OPSGENIE_API_KEY: ${{ secrets.OPSGENIE_API_KEY }}
           SLACK_WEB_API_TOKEN: ${{ secrets.SLACK_WEB_API_TOKEN }}

--- a/.github/workflows/standup-reminder.yml
+++ b/.github/workflows/standup-reminder.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Run CLI
         id: cli
-        run: echo "PAYLOAD=$(artsy scheduled:standup-reminder)" >> $GITHUB_PAYLOAD
+        run: echo "PAYLOAD=$(artsy scheduled:standup-reminder)" >> $GITHUB_OUTPUT
         env:
           OPSGENIE_API_KEY: ${{ secrets.OPSGENIE_API_KEY }}
           SLACK_WEB_API_TOKEN: ${{ secrets.SLACK_WEB_API_TOKEN }}


### PR DESCRIPTION
This reverts the [revert](https://github.com/artsy/joule/pull/138) and includes a fix to address the typo in GITHUB environment variable.

Example of the [GHA which didn't contain the typo](https://github.com/artsy/joule/actions/runs/5046715045) succeeding this morning.