### PR TITLE
chore: simplify S3 path for shared configuration

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -20,7 +20,7 @@ echo "Installing dependencies..."
 yarn install || (npm install --global yarn@latest && yarn install)
 
 echo 'Updating .env file (for shared configuration)...'
-aws s3 cp s3://artsy-citadel/dev/.env.joule .env || 'Unable to download shared configuration, ensure you have S3 access!'
+aws s3 cp s3://artsy-citadel/joule/.env ./ || 'Unable to download shared configuration, ensure you have S3 access!'
 
 echo 'Setup complete! To start the server, run:
   yarn start'


### PR DESCRIPTION
As per https://github.com/artsy/README/pull/530, this updates setup to pull shared configuration from its new, simpler location.