### PR TITLE
feat: Adding the dev-help helper functionality and a bug workflow reminder

### DIFF
--- a/app.js
+++ b/app.js
@@ -206,15 +206,13 @@ app.action(ACTION_MARK_SOLVED, async ({ action, ack, respond, client, body }) =>
 
     if (!channel) throw new Error("Channel is undefined");
     if (!ts) throw new Error("Timestamp is undefined");
-    
+
     await addCheckmarkReaction({ client, channel: body.channel.id, timestamp: ts });
     await respond({ delete_original: true });
 
   } catch (error) {
     console.error("Error adding checkmark reaction:", error);
   }
-
-  console.log("ACTION_MARK_SOLVED END ~")
 });
 
 if (process.env.DEBUG) {


### PR DESCRIPTION
This PR contains:
- The dev-help helper functionality from [here](https://github.com/artsy/dev-help-helper-bot/blob/main/index.js) converted to use the bolt sdk
- Adding a button to the dev-helper reply, that adds the ✅ to the top thread, in addition to the `solved` reply. 
- A Product Bugs Workflow reminder already approved [here](https://github.com/artsy/dev-help-helper-bot/pull/30) by @joeyAghion
