### PR TITLE
chore: Add 'wrong' keyword to Joule workflow regex

### DIFF
--- a/app.js
+++ b/app.js
@@ -137,7 +137,7 @@ async function processThreadMessagesForGratitude(client, event) {
 async function processTopMessagesForBugWorkflowReminder(client, event) {
   if (!CHANNELS_FOR_BUGS_WORKFLOW_REMINDER.includes(event.channel)) return;
 
-  const issueWordsRegex = /(bug|issue|error|reproduce|complain|replicate)/i;
+  const issueWordsRegex = /(bug|issue|error|reproduce|complain|replicate|wrong)/i;
   const ignoreWordsRegex = /feedback/i;
   const reminderMessage = `Oops! 🐞\nIt seems you found a bug, <@${event.user}>. Please use the 'Report a Bug' workflow. Thanks! 🙌`;
 


### PR DESCRIPTION
This PR updates the regular expression used by Joule to include the keyword 'wrong'. This ensures that Joule reminds users of the workflow when this keyword is detected.