### PR TITLE
chore: Adding product-bugs and product-questions reminder to use the reminder

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,8 +10,9 @@ const CHANNELS_TO_EXCLUDE = [
   // 'C012K7XU4LE', // #bot-testing
 ];
 const CHANNELS_FOR_BUGS_WORKFLOW_REMINDER = [
-  "C02E1D1G3B3", // #chr-test
-  "C03N12SR0RK", // #product-bugs-and-feedback
+  "C02E1D1G3B3", // #chr-test 
+  "C03N12SR0RK", // #product-questions
+  "C07PRTJSD6G", // #product-bugs
 ];
 
 const receiver = new ExpressReceiver({


### PR DESCRIPTION
- Adding product-bugs to the reminder filter
- Updating the reminder filter name to match the new channel name: product-questions