### PR TITLE
fix: use explicit path to project-local artsy cli, instead of global

### DIFF
--- a/.github/workflows/facilitate-incident-review.yml
+++ b/.github/workflows/facilitate-incident-review.yml
@@ -16,12 +16,15 @@ jobs:
         with:
           node-version: "22"
 
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
       - name: Install Dependencies
-        run: npm install --global @artsy/cli
+        run: yarn install
 
       - name: Run CLI
         id: cli
-        run: echo "PAYLOAD=$(artsy scheduled:facilitate-incident-review --useDatesVar)" >> "$GITHUB_OUTPUT"
+        run: echo "PAYLOAD=$(/home/runner/work/joule/joule/node_modules/.bin/artsy scheduled:facilitate-incident-review --useDatesVar)" >> "$GITHUB_OUTPUT"
         env:
           OPSGENIE_API_KEY: ${{ secrets.OPSGENIE_API_KEY }}
           SLACK_WEB_API_TOKEN: ${{ secrets.SLACK_WEB_API_TOKEN }}

--- a/.github/workflows/next-on-call.yml
+++ b/.github/workflows/next-on-call.yml
@@ -14,14 +14,17 @@ jobs:
       - name: Setup Node.JS
         uses: actions/setup-node@v2
         with:
-          node-version: "12"
+          node-version: "22"
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
       - name: Install Dependencies
-        run: npm install --global @artsy/cli
+        run: yarn install
 
       - name: Run CLI
         id: cli
-        run: echo "PAYLOAD=$(artsy scheduled:next-on-call)" >> "$GITHUB_OUTPUT"
+        run: echo "PAYLOAD=$(/home/runner/work/joule/joule/node_modules/.bin/artsy scheduled:next-on-call)" >> "$GITHUB_OUTPUT"
         env:
           OPSGENIE_API_KEY: ${{ secrets.OPSGENIE_API_KEY }}
           SLACK_WEB_API_TOKEN: ${{ secrets.SLACK_WEB_API_TOKEN }}

--- a/.github/workflows/open-rfcs.yml
+++ b/.github/workflows/open-rfcs.yml
@@ -22,21 +22,16 @@ jobs:
       - name: Install Dependencies
         run: yarn install
 
-      - name: Preview CLI
-        run: echo "PAYLOAD=$(/home/runner/work/joule/joule/node_modules/.bin/artsy scheduled:rfcs)"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-
       - name: Run CLI
         id: cli
         run: echo "PAYLOAD=$(/home/runner/work/joule/joule/node_modules/.bin/artsy scheduled:rfcs)" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 
-      # - name: Open RFCs > Slack
-      #   uses: 8398a7/action-slack@v3
-      #   with:
-      #     status: custom
-      #     custom_payload: ${{steps.cli.outputs.PAYLOAD}}
-      #   env:
-      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - name: Open RFCs > Slack
+        uses: 8398a7/action-slack@v3
+        with:
+          status: custom
+          custom_payload: ${{steps.cli.outputs.PAYLOAD}}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/open-rfcs.yml
+++ b/.github/workflows/open-rfcs.yml
@@ -14,21 +14,29 @@ jobs:
       - name: Setup Node.JS
         uses: actions/setup-node@v2
         with:
-          node-version: "12"
+          node-version: "22"
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
       - name: Install Dependencies
-        run: npm install --global @artsy/cli@0.26.1
+        run: yarn install
 
-      - name: Run CLI
-        id: cli
-        run: echo "PAYLOAD=$(artsy scheduled:rfcs)" >> "$GITHUB_OUTPUT"
+      - name: Preview CLI
+        run: echo "PAYLOAD=$(/home/runner/work/joule/joule/node_modules/.bin/artsy scheduled:rfcs)"
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 
-      - name: Open RFCs > Slack
-        uses: 8398a7/action-slack@v3
-        with:
-          status: custom
-          custom_payload: ${{steps.cli.outputs.PAYLOAD}}
+      - name: Run CLI
+        id: cli
+        run: echo "PAYLOAD=$(/home/runner/work/joule/joule/node_modules/.bin/artsy scheduled:rfcs)" >> "$GITHUB_OUTPUT"
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+
+      # - name: Open RFCs > Slack
+      #   uses: 8398a7/action-slack@v3
+      #   with:
+      #     status: custom
+      #     custom_payload: ${{steps.cli.outputs.PAYLOAD}}
+      #   env:
+      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/recently-published.yml
+++ b/.github/workflows/recently-published.yml
@@ -14,14 +14,17 @@ jobs:
       - name: Setup Node.JS
         uses: actions/setup-node@v2
         with:
-          node-version: "12"
+          node-version: "22"
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
       - name: Install Dependencies
-        run: npm install --global @artsy/cli
+        run: yarn install
 
       - name: Run CLI
         id: cli
-        run: echo "PAYLOAD=$(artsy scheduled:recently-published)" >> "$GITHUB_OUTPUT"
+        run: echo "PAYLOAD=$(/home/runner/work/joule/joule/node_modules/.bin/artsy scheduled:recently-published)" >> "$GITHUB_OUTPUT"
         env:
           SLACK_WEB_API_TOKEN: ${{ secrets.SLACK_WEB_API_TOKEN }}
 

--- a/.github/workflows/sapphire-on-call-retro.yml
+++ b/.github/workflows/sapphire-on-call-retro.yml
@@ -30,14 +30,17 @@ jobs:
       - name: Setup Node.JS
         uses: actions/setup-node@v2
         with:
-          node-version: "12"
+          node-version: "22"
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
       - name: Install Dependencies
-        run: npm install --global @artsy/cli
+        run: yarn install
 
       - name: Run CLI
         id: cli
-        run: echo "PAYLOAD=$(artsy scheduled:sapphire-on-call-retro)" >> "$GITHUB_OUTPUT"
+        run: echo "PAYLOAD=$(/home/runner/work/joule/joule/node_modules/.bin/artsy scheduled:sapphire-on-call-retro)" >> "$GITHUB_OUTPUT"
         env:
           OPSGENIE_API_KEY: ${{ secrets.OPSGENIE_API_KEY }}
           SLACK_WEB_API_TOKEN: ${{ secrets.SLACK_WEB_API_TOKEN }}

--- a/.github/workflows/sapphire-on-call.yml
+++ b/.github/workflows/sapphire-on-call.yml
@@ -14,14 +14,17 @@ jobs:
       - name: Setup Node.JS
         uses: actions/setup-node@v2
         with:
-          node-version: "12"
+          node-version: "22"
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
       - name: Install Dependencies
-        run: npm install --global @artsy/cli
+        run: yarn install
 
       - name: Run CLI
         id: cli
-        run: echo "PAYLOAD=$(artsy scheduled:sapphire-on-call)" >> "$GITHUB_OUTPUT"
+        run: echo "PAYLOAD=$(/home/runner/work/joule/joule/node_modules/.bin/artsy scheduled:sapphire-on-call)" >> "$GITHUB_OUTPUT"
         env:
           OPSGENIE_API_KEY: ${{ secrets.OPSGENIE_API_KEY }}
           SLACK_WEB_API_TOKEN: ${{ secrets.SLACK_WEB_API_TOKEN }}

--- a/.github/workflows/security-bounty-rotation.yml
+++ b/.github/workflows/security-bounty-rotation.yml
@@ -14,14 +14,17 @@ jobs:
       - name: Setup Node.JS
         uses: actions/setup-node@v2
         with:
-          node-version: "12"
+          node-version: "22"
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
       - name: Install Dependencies
-        run: npm install --global @artsy/cli
+        run: yarn install
 
       - name: Run CLI
         id: cli
-        run: echo "PAYLOAD=$(artsy scheduled:security-bounty-rotation)" >> "$GITHUB_OUTPUT"
+        run: echo "PAYLOAD=$(/home/runner/work/joule/joule/node_modules/.bin/artsy scheduled:security-bounty-rotation)" >> "$GITHUB_OUTPUT"
         env:
           OPSGENIE_API_KEY: ${{ secrets.OPSGENIE_API_KEY }}
           SLACK_WEB_API_TOKEN: ${{ secrets.SLACK_WEB_API_TOKEN }}

--- a/.github/workflows/standup-reminder.yml
+++ b/.github/workflows/standup-reminder.yml
@@ -14,14 +14,17 @@ jobs:
       - name: Setup Node.JS
         uses: actions/setup-node@v2
         with:
-          node-version: "12"
+          node-version: "22"
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
       - name: Install Dependencies
-        run: npm install --global @artsy/cli
+        run: yarn install
 
       - name: Run CLI
         id: cli
-        run: echo "PAYLOAD=$(artsy scheduled:standup-reminder)" >> "$GITHUB_OUTPUT"
+        run: echo "PAYLOAD=$(/home/runner/work/joule/joule/node_modules/.bin/artsy scheduled:standup-reminder)" >> "$GITHUB_OUTPUT"
         env:
           OPSGENIE_API_KEY: ${{ secrets.OPSGENIE_API_KEY }}
           SLACK_WEB_API_TOKEN: ${{ secrets.SLACK_WEB_API_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "node": ">=22.0.0"
   },
   "dependencies": {
-    "@artsy/cli": "^1.7.0",
+    "@artsy/cli": "^1.12.1",
     "@slack/bolt": "^3.12.1",
     "dotenv": "^10.0.0",
     "shell-quote": "^1.8.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@artsy/cli@^1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@artsy/cli/-/cli-1.7.0.tgz#1ea755c4f6aa5bf6d23aa03b5dd263ddde8ed495"
-  integrity sha512-yiFuYQiC6PTNhgqmOw0FbWtt0JPo6NjP/miT6dxtCg5Q/v65xELz5UDnAfRv1dEIwvmdHXEwNYK+ark4EyqmJA==
+"@artsy/cli@^1.12.1":
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/@artsy/cli/-/cli-1.13.1.tgz#d62bc4a82234a9a3910cfa1c7f1fe7b9e7be3a28"
+  integrity sha512-IWB7BwMNoOwC14gWXENUIlN5zLL7GiKpjGNy4kJnp4bGAguQ40Ehof42mVQ1sQItCVfAlrbHiIy0w60pAOXKZQ==
   dependencies:
     "@oclif/command" "^1"
     "@oclif/config" "^1"


### PR DESCRIPTION
Paired with @anandaroop 

We discovered during a recent NPM package compromise that we were not using package versions pinned in artsy/cli's **yarn.lock** file like we expected. Some research showed us that when you install packages with `npm install --global` the package versions are ignored. Here we are switching to installing and running artsy cli via yarn instead.

Some things to note:
* We had to put the full path to the artsy binary instead of just `yarn artsy...` in each command as we were facing issues with [newlines breaking the output format](https://github.com/artsy/joule/actions/runs/18228594727/job/51906153129#step:6:9).
* We've also bumped the artsy/cli version to ^1.12.1 as some of the commands were not in the old version we were using. In hindsight, this was already a strong hint package versions were not being respected.
* Node versions have been upgraded where applicable. 