### PR TITLE
chore: Change the day incident review facilitator from Monday to Wednesday

### DIFF
--- a/.github/workflows/facilitate-incident-review.yml
+++ b/.github/workflows/facilitate-incident-review.yml
@@ -3,7 +3,7 @@ name: Facilitate Incident Review
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 14 * * TUE"
+    - cron: "0 14 * * WED"
 
 jobs:
   facilitate-incident-review:

--- a/.github/workflows/facilitate-incident-review.yml
+++ b/.github/workflows/facilitate-incident-review.yml
@@ -3,7 +3,7 @@ name: Facilitate Incident Review
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 14 * * MON"
+    - cron: "0 14 * * TUE"
 
 jobs:
   facilitate-incident-review:


### PR DESCRIPTION
The incident reviews are now on Wednesdays. Changing the day of the message from Monday to Wednesday