### PR TITLE
feat: reply with recording URL to new Hotjar recording messages

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,6 +18,7 @@ const CHANNELS_FOR_BUGS_WORKFLOW_REMINDER = [
   "C03N12SR0RK", // #product-questions
   "C07PRTJSD6G", // #product-bugs
 ];
+const HOTJAR_RECORDING_CHANNEL = "C0BGS6HHV63"; // #amber-hotjar
 
 const receiver = new ExpressReceiver({
   signingSecret: process.env.SLACK_SIGNING_SECRET,
@@ -226,6 +227,34 @@ async function processEmeraldP2Messages(client, event) {
   }
 }
 
+function extractWatchRecordingUrl(event) {
+  const buttons = event.blocks?.flatMap((block) => {
+    if (block.type === "actions") return block.elements || [];
+    if (block.accessory?.type === "button") return [block.accessory];
+    return [];
+  });
+  const button = buttons?.find((el) => el.text?.text?.includes("Watch Recording"));
+  return button?.url;
+}
+
+async function processHotjarRecordingMessages(client, event) {
+  try {
+    if (event.channel !== HOTJAR_RECORDING_CHANNEL) return;
+    if (!event.text?.trim().startsWith("New recording available")) return;
+
+    const url = extractWatchRecordingUrl(event);
+    if (!url) return;
+
+    await client.chat.postMessage({
+      channel: event.channel,
+      thread_ts: event.ts,
+      text: `URL: ${url}`,
+    });
+  } catch (error) {
+    console.error("[hotjar] Error processing Hotjar recording message:", error);
+  }
+}
+
 app.message(onlyDirectMessages, /^cli (?<args>\S.*)$/, processCLICommand)
 app.message(directMention(), /^<@U\S+> cli (?<args>\S.*)$/, processCLICommand)
 
@@ -246,6 +275,7 @@ app.message(async ({ client, message, event }) => {
 
   await processIncidentMessages(client, event);
   await processEmeraldP2Messages(client, event);
+  await processHotjarRecordingMessages(client, event);
 
 });
 


### PR DESCRIPTION
## What
In #amber-hotjar, adds an automation that watches for Hotjar's "New recording available" messages and replies in-thread with `URL: <recording link>`.

## Why
Hotjar posts the recording link only inside a hidden Slack button (`accessory`/`actions` block `url`), not as visible text, so it doesn't show up as a link or unfurl in the channel. This surfaces the URL as plain, readable/searchable text. The URL will be useful for Claude automation, which unfortunately cannot real button URLs. 

## How
- `extractWatchRecordingUrl` pulls the URL from the button labeled "Watch Recording", whether it's a `section` block's `accessory` or inside an `actions` block (Hotjar's real payload uses the `accessory` form).
- `processHotjarRecordingMessages` gates on channel (`HOTJAR_RECORDING_CHANNEL` = #amber-hotjar) and message text starting with "New recording available", then posts the threaded reply.
- Wired into the existing `app.message` handler alongside the other message processors.

Verified locally against #chr-test with real Hotjar test recordings before pointing at #amber-hotjar.

Create with Claude Sonnet. 