### PR TITLE
feat: reply with results dashboard URL to new Maze response messages

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,6 +19,7 @@ const CHANNELS_FOR_BUGS_WORKFLOW_REMINDER = [
   "C07PRTJSD6G", // #product-bugs
 ];
 const HOTJAR_RECORDING_CHANNEL = "C0BGS6HHV63"; // #amber-hotjar
+const MAZE_RESPONSE_CHANNEL = "C0BHC6GEXC7"; // #amber-maze
 
 const receiver = new ExpressReceiver({
   signingSecret: process.env.SLACK_SIGNING_SECRET,
@@ -227,13 +228,13 @@ async function processEmeraldP2Messages(client, event) {
   }
 }
 
-function extractWatchRecordingUrl(event) {
+function extractButtonUrl(event, label) {
   const buttons = event.blocks?.flatMap((block) => {
     if (block.type === "actions") return block.elements || [];
     if (block.accessory?.type === "button") return [block.accessory];
     return [];
   });
-  const button = buttons?.find((el) => el.text?.text?.includes("Watch Recording"));
+  const button = buttons?.find((el) => el.text?.text?.includes(label));
   return button?.url;
 }
 
@@ -242,7 +243,7 @@ async function processHotjarRecordingMessages(client, event) {
     if (event.channel !== HOTJAR_RECORDING_CHANNEL) return;
     if (!event.text?.trim().startsWith("New recording available")) return;
 
-    const url = extractWatchRecordingUrl(event);
+    const url = extractButtonUrl(event, "Watch Recording");
     if (!url) return;
 
     await client.chat.postMessage({
@@ -252,6 +253,24 @@ async function processHotjarRecordingMessages(client, event) {
     });
   } catch (error) {
     console.error("[hotjar] Error processing Hotjar recording message:", error);
+  }
+}
+
+async function processMazeResponseMessages(client, event) {
+  try {
+    if (event.channel !== MAZE_RESPONSE_CHANNEL) return;
+    if (!event.text?.includes("You have a new response:")) return;
+
+    const url = extractButtonUrl(event, "View results dashboard");
+    if (!url) return;
+
+    await client.chat.postMessage({
+      channel: event.channel,
+      thread_ts: event.ts,
+      text: `URL: ${url}`,
+    });
+  } catch (error) {
+    console.error("[maze] Error processing Maze response message:", error);
   }
 }
 
@@ -276,6 +295,7 @@ app.message(async ({ client, message, event }) => {
   await processIncidentMessages(client, event);
   await processEmeraldP2Messages(client, event);
   await processHotjarRecordingMessages(client, event);
+  await processMazeResponseMessages(client, event);
 
 });
 


### PR DESCRIPTION
## What
In #amber-maze, adds an automation that watches for Maze's "You have a new response:" messages and replies in-thread with `URL: <results dashboard link>`.

## Why
Same motivation as the Hotjar automation (#213): the results dashboard link is only reachable via a hidden Slack button, not visible as text, so it doesn't unfurl or show up as a link in the channel.

## How
- Reuses the generic `extractButtonUrl(event, label)` helper (extracted from the Hotjar automation) to pull the URL from the button labeled "View results dashboard", whether it's a `section` block's `accessory` or inside an `actions` block.
- `processMazeResponseMessages` gates on channel (`MAZE_RESPONSE_CHANNEL` = #amber-maze) and message text containing "You have a new response:", then posts the threaded reply.
- Wired into the existing `app.message` handler alongside the other message processors.

## Note for reviewer
Not yet verified locally against a live Maze payload (unlike Hotjar, where we caught a leading-whitespace/`accessory`-vs-`actions` mismatch during local testing). Plan to verify with `yarn start` + `yarn ngrok` against a real test response in #amber-maze before merging — will adjust the extractor if the block shape differs.