### PR TITLE
fix: match Maze notification text for new response trigger

### DIFF
--- a/app.js
+++ b/app.js
@@ -259,7 +259,7 @@ async function processHotjarRecordingMessages(client, event) {
 async function processMazeResponseMessages(client, event) {
   try {
     if (event.channel !== MAZE_RESPONSE_CHANNEL) return;
-    if (!event.text?.includes("You have a new response:")) return;
+    if (!event.text?.includes("new response")) return;
 
     const url = extractButtonUrl(event, "View results dashboard");
     if (!url) return;


### PR DESCRIPTION
## What
Fixes the trigger condition for the Maze automation so it actually fires.

## Why
The merged Maze automation (#216) gated on `event.text.includes("You have a new response:")`. Verified locally that Maze's Slack message `text` field is actually the notification fallback.

## How
Changed the check to `event.text.includes("new response")`, which matches Maze's real `text` value. Confirmed working end-to-end locally (bot replies in-thread with the results dashboard URL).