### PR TITLE
feat: cut over next-on-call to incident.io via duchamp

### DIFF
--- a/.github/workflows/next-on-call.yml
+++ b/.github/workflows/next-on-call.yml
@@ -2,14 +2,47 @@ name: Next On Call
 
 on:
   workflow_dispatch:
+    inputs:
+      # Only the two production target combinations are selectable here. To
+      # test an arbitrary weekday/hour, run scripts/on-call/next-on-call.ts
+      # locally with NEXT_ON_CALL_TARGET_WEEKDAY/HOUR set directly instead.
+      mode:
+        description: "Which run to simulate"
+        required: true
+        type: choice
+        options:
+          - monday-safety-cutoff
+          - thursday-rotation-boundary
+        default: thursday-rotation-boundary
   schedule:
-    - cron: "0 14 * * MON,THU"
+    - cron: "0 14 * * MON"
+    - cron: "0 14 * * THU"
 
 jobs:
-  next-on-call:
+  # Runs right after the rot-na/sa handoff (Monday). Targets a generous
+  # cutoff (Friday, midnight ET) rather than the next real boundary
+  # (Wednesday's rot-eu/uk handoff), so coverage still extends past the
+  # Thursday run below even if that run ends up firing late.
+  monday-safety-cutoff:
+    if: github.event.schedule == '0 14 * * MON' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'monday-safety-cutoff')
     uses: artsy/duchamp/.github/workflows/incident-next-on-call.yml@main
     with:
       schedule-id: ${{ vars.INCIDENT_IO_SCHEDULE_ID }}
+      target-weekday: 5 # Friday
+      target-hour: 0 # midnight ET
+    secrets:
+      incident-io-api-key: ${{ secrets.INCIDENT_IO_API_KEY }}
+      slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  # Runs a few days before the rot-na/sa handoff (Thursday). Targets that
+  # real boundary (Monday, 11am ET) directly.
+  thursday-rotation-boundary:
+    if: github.event.schedule == '0 14 * * THU' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'thursday-rotation-boundary')
+    uses: artsy/duchamp/.github/workflows/incident-next-on-call.yml@main
+    with:
+      schedule-id: ${{ vars.INCIDENT_IO_SCHEDULE_ID }}
+      target-weekday: 1 # Monday
+      target-hour: 11 # 11am ET
     secrets:
       incident-io-api-key: ${{ secrets.INCIDENT_IO_API_KEY }}
       slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/next-on-call.yml
+++ b/.github/workflows/next-on-call.yml
@@ -7,32 +7,9 @@ on:
 
 jobs:
   next-on-call:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-
-    steps:
-      - name: Setup Node.JS
-        uses: actions/setup-node@v2
-        with:
-          node-version: "22"
-
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Install Dependencies
-        run: yarn install
-
-      - name: Run CLI
-        id: cli
-        run: echo "PAYLOAD=$(/home/runner/work/joule/joule/node_modules/.bin/artsy scheduled:next-on-call)" >> "$GITHUB_OUTPUT"
-        env:
-          OPSGENIE_API_KEY: ${{ secrets.OPSGENIE_API_KEY }}
-          SLACK_WEB_API_TOKEN: ${{ secrets.SLACK_WEB_API_TOKEN }}
-
-      - name: Standup Reminder > Slack
-        uses: 8398a7/action-slack@v3
-        with:
-          status: custom
-          custom_payload: ${{steps.cli.outputs.PAYLOAD}}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    uses: artsy/duchamp/.github/workflows/incident-next-on-call.yml@main
+    with:
+      schedule-id: ${{ vars.INCIDENT_IO_SCHEDULE_ID }}
+    secrets:
+      incident-io-api-key: ${{ secrets.INCIDENT_IO_API_KEY }}
+      slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/next-on-call.yml
+++ b/.github/workflows/next-on-call.yml
@@ -19,10 +19,11 @@ on:
     - cron: "0 14 * * THU"
 
 jobs:
-  # Runs right after the rot-na/sa handoff (Monday). Targets a generous
-  # cutoff (Friday, midnight ET) rather than the next real boundary
-  # (Wednesday's rot-eu/uk handoff), so coverage still extends past the
-  # Thursday run below even if that run ends up firing late.
+  # Runs on the rot-na/sa handoff day (Monday) — the cron fires at 10am ET,
+  # before the actual 11am ET boundary. Targets a generous cutoff (Friday,
+  # midnight ET) rather than the next real boundary (Wednesday's rot-eu/uk
+  # handoff), so coverage still extends past the Thursday run below even if
+  # that run ends up firing late.
   monday-safety-cutoff:
     if: github.event.schedule == '0 14 * * MON' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'monday-safety-cutoff')
     uses: artsy/duchamp/.github/workflows/incident-next-on-call.yml@main


### PR DESCRIPTION
## Summary
- Replaces the Opsgenie-based `next-on-call` cli command with a call to duchamp's new `incident-next-on-call.yml` reusable workflow
- Split into two jobs (`monday-safety-cutoff`, `thursday-rotation-boundary`), one per existing cron day, each passing its own literal target weekday/hour
- `workflow_dispatch` now takes a `mode` input to pick which job to exercise manually
- Depends on https://github.com/artsy/duchamp/pull/106 merging first.

## Test plan
- [x] Manually triggered via `workflow_dispatch` for both modes and confirmed correct Slack output against real schedule data

Assisted-by: Claude:Sonnet-5 [Claude Code]