### PR TITLE
feat: cut over facilitate-incident-review to incident.io via duchamp

### DIFF
--- a/.github/workflows/facilitate-incident-review.yml
+++ b/.github/workflows/facilitate-incident-review.yml
@@ -6,36 +6,19 @@ on:
     - cron: "0 14 * * WED"
 
 jobs:
-  facilitate-incident-review:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-
-    steps:
-      - name: Setup Node.JS
-        uses: actions/setup-node@v3
-        with:
-          node-version: "22"
-
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Install Dependencies
-        run: yarn install
-
-      - name: Run CLI
-        id: cli
-        run: echo "PAYLOAD=$(/home/runner/work/joule/joule/node_modules/.bin/artsy scheduled:facilitate-incident-review --enableBiweeklySchedule)" >> "$GITHUB_OUTPUT"
-        env:
-          OPSGENIE_API_KEY: ${{ secrets.OPSGENIE_API_KEY }}
-          SLACK_WEB_API_TOKEN: ${{ secrets.SLACK_WEB_API_TOKEN }}
-          DATES: ${{ vars.DATES }}
-          FACILITATOR_SELECTION_DAY: ${{ vars.FACILITATOR_SELECTION_DAY }}
-
-      - name: CLI payload > Slack
-        if: ${{ steps.cli.outputs.PAYLOAD != 'Off week' }}
-        uses: 8398a7/action-slack@v3
-        with:
-          status: custom
-          custom_payload: ${{ steps.cli.outputs.PAYLOAD }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  facilitate-review:
+    uses: artsy/duchamp/.github/workflows/incident-facilitate-review.yml@main
+    with:
+      schedule-id: ${{ vars.INCIDENT_IO_SCHEDULE_ID }}
+      meeting-weekday: ${{ vars.MEETING_WEEKDAY }}
+      meeting-hour: ${{ vars.MEETING_HOUR }}
+      meeting-minute: ${{ vars.MEETING_MINUTE }}
+      # The routine Wednesday cron only needs to see 1 day ahead (tomorrow's
+      # regular meeting). An occasional manual catch-up trigger needs enough
+      # slack to reach an off-week `exceptions` date on any weekday (e.g.
+      # triggered the Friday before a Monday catch-up).
+      lookahead-days: ${{ github.event_name == 'schedule' && 1 || 6 }}
+      dates: ${{ vars.DATES }}
+    secrets:
+      incident-io-api-key: ${{ secrets.INCIDENT_IO_API_KEY }}
+      slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/facilitate-incident-review.yml
+++ b/.github/workflows/facilitate-incident-review.yml
@@ -2,6 +2,11 @@ name: Facilitate Incident Review
 
 on:
   workflow_dispatch:
+    inputs:
+      meeting-date:
+        description: "Override meeting date (YYYY-MM-DD) — only for a rare off-week catch-up review, leave blank otherwise"
+        required: false
+        type: string
   schedule:
     - cron: "0 14 * * WED"
 
@@ -13,12 +18,8 @@ jobs:
       meeting-weekday: ${{ vars.MEETING_WEEKDAY }}
       meeting-hour: ${{ vars.MEETING_HOUR }}
       meeting-minute: ${{ vars.MEETING_MINUTE }}
-      # The routine Wednesday cron only needs to see 1 day ahead (tomorrow's
-      # regular meeting). An occasional manual catch-up trigger needs enough
-      # slack to reach an off-week `exceptions` date on any weekday (e.g.
-      # triggered the Friday before a Monday catch-up).
-      lookahead-days: ${{ github.event_name == 'schedule' && 1 || 6 }}
-      dates: ${{ vars.DATES }}
+      base-date: ${{ vars.MEETING_BASE_DATE }}
+      override-date: ${{ github.event.inputs.meeting-date }}
     secrets:
       incident-io-api-key: ${{ secrets.INCIDENT_IO_API_KEY }}
       slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary

Replaces the old `artsy/cli scheduled:facilitate-incident-review` cli invocation with a call to duchamp's new `incident-facilitate-review.yml` reusable workflow (see [duchamp#109](https://github.com/artsy/duchamp/pull/109)) — the third and final phase of the Opsgenie → incident.io on-call migration (PHIRE-3295). Adds a `meeting-date` `workflow_dispatch` input for triggering a rare off-week catch-up review manually.

## Required before merge

- [x] Set repo variable `MEETING_WEEKDAY` = `4`
- [x] Set repo variable `MEETING_HOUR` = `11`
- [x] Set repo variable `MEETING_MINUTE` = `30`
- [x] Set repo variable `MEETING_BASE_DATE` = `2023-04-27`

## Required after merge

- [x] Unset the now-unused repo variables `DATES` and `FACILITATOR_SELECTION_DAY`

## Test plan

- [x] Manually ran the underlying script locally against the real incident.io API and confirmed correct output (see duchamp#109)

Assisted-by: Claude:Sonnet-5 [Claude Code]