### PR TITLE
ci: pass Orbit env vars to the sapphire/security-bounty workflows

### DIFF
--- a/.github/workflows/sapphire-on-call-retro.yml
+++ b/.github/workflows/sapphire-on-call-retro.yml
@@ -44,9 +44,9 @@ jobs:
         env:
           OPSGENIE_API_KEY: ${{ secrets.OPSGENIE_API_KEY }}
           SLACK_WEB_API_TOKEN: ${{ secrets.SLACK_WEB_API_TOKEN }}
-          ORBIT_URL: ${{ secrets.ORBIT_URL }}
+          ORBIT_URL: ${{ secrets.ORBIT_URL || vars.ORBIT_URL }}
           ORBIT_TOKEN: ${{ secrets.ORBIT_TOKEN }}
-          ORBIT_SAPPHIRE_RETRO_ROTATION_ID: ${{ secrets.ORBIT_SAPPHIRE_RETRO_ROTATION_ID }}
+          ORBIT_SAPPHIRE_RETRO_ROTATION_ID: ${{ vars.ORBIT_SAPPHIRE_RETRO_ROTATION_ID }}
 
       - name: Standup Reminder > Slack
         uses: 8398a7/action-slack@v3

--- a/.github/workflows/sapphire-on-call-retro.yml
+++ b/.github/workflows/sapphire-on-call-retro.yml
@@ -44,6 +44,9 @@ jobs:
         env:
           OPSGENIE_API_KEY: ${{ secrets.OPSGENIE_API_KEY }}
           SLACK_WEB_API_TOKEN: ${{ secrets.SLACK_WEB_API_TOKEN }}
+          ORBIT_URL: ${{ secrets.ORBIT_URL }}
+          ORBIT_TOKEN: ${{ secrets.ORBIT_TOKEN }}
+          ORBIT_SAPPHIRE_RETRO_ROTATION_ID: ${{ secrets.ORBIT_SAPPHIRE_RETRO_ROTATION_ID }}
 
       - name: Standup Reminder > Slack
         uses: 8398a7/action-slack@v3

--- a/.github/workflows/sapphire-on-call.yml
+++ b/.github/workflows/sapphire-on-call.yml
@@ -28,6 +28,9 @@ jobs:
         env:
           OPSGENIE_API_KEY: ${{ secrets.OPSGENIE_API_KEY }}
           SLACK_WEB_API_TOKEN: ${{ secrets.SLACK_WEB_API_TOKEN }}
+          ORBIT_URL: ${{ secrets.ORBIT_URL }}
+          ORBIT_TOKEN: ${{ secrets.ORBIT_TOKEN }}
+          ORBIT_SAPPHIRE_ROTATION_ID: ${{ secrets.ORBIT_SAPPHIRE_ROTATION_ID }}
 
       - name: Standup Reminder > Slack
         uses: 8398a7/action-slack@v3

--- a/.github/workflows/sapphire-on-call.yml
+++ b/.github/workflows/sapphire-on-call.yml
@@ -28,9 +28,9 @@ jobs:
         env:
           OPSGENIE_API_KEY: ${{ secrets.OPSGENIE_API_KEY }}
           SLACK_WEB_API_TOKEN: ${{ secrets.SLACK_WEB_API_TOKEN }}
-          ORBIT_URL: ${{ secrets.ORBIT_URL }}
+          ORBIT_URL: ${{ secrets.ORBIT_URL || vars.ORBIT_URL }}
           ORBIT_TOKEN: ${{ secrets.ORBIT_TOKEN }}
-          ORBIT_SAPPHIRE_ROTATION_ID: ${{ secrets.ORBIT_SAPPHIRE_ROTATION_ID }}
+          ORBIT_SAPPHIRE_ROTATION_ID: ${{ vars.ORBIT_SAPPHIRE_ROTATION_ID }}
 
       - name: Standup Reminder > Slack
         uses: 8398a7/action-slack@v3

--- a/.github/workflows/security-bounty-rotation.yml
+++ b/.github/workflows/security-bounty-rotation.yml
@@ -28,6 +28,9 @@ jobs:
         env:
           OPSGENIE_API_KEY: ${{ secrets.OPSGENIE_API_KEY }}
           SLACK_WEB_API_TOKEN: ${{ secrets.SLACK_WEB_API_TOKEN }}
+          ORBIT_URL: ${{ secrets.ORBIT_URL }}
+          ORBIT_TOKEN: ${{ secrets.ORBIT_TOKEN }}
+          ORBIT_SECURITY_BOUNTY_ROTATION_ID: ${{ secrets.ORBIT_SECURITY_BOUNTY_ROTATION_ID }}
 
       - name: Standup Reminder > Slack
         uses: 8398a7/action-slack@v3

--- a/.github/workflows/security-bounty-rotation.yml
+++ b/.github/workflows/security-bounty-rotation.yml
@@ -28,9 +28,9 @@ jobs:
         env:
           OPSGENIE_API_KEY: ${{ secrets.OPSGENIE_API_KEY }}
           SLACK_WEB_API_TOKEN: ${{ secrets.SLACK_WEB_API_TOKEN }}
-          ORBIT_URL: ${{ secrets.ORBIT_URL }}
+          ORBIT_URL: ${{ secrets.ORBIT_URL || vars.ORBIT_URL }}
           ORBIT_TOKEN: ${{ secrets.ORBIT_TOKEN }}
-          ORBIT_SECURITY_BOUNTY_ROTATION_ID: ${{ secrets.ORBIT_SECURITY_BOUNTY_ROTATION_ID }}
+          ORBIT_SECURITY_BOUNTY_ROTATION_ID: ${{ vars.ORBIT_SECURITY_BOUNTY_ROTATION_ID }}
 
       - name: Standup Reminder > Slack
         uses: 8398a7/action-slack@v3


### PR DESCRIPTION
**Draft — companion to [artsy/cli#331](https://github.com/artsy/cli/pull/331), don't merge before that one.**

Adds the Orbit env vars to the three scheduled workflows that invoke `scheduled:sapphire-on-call`, `scheduled:sapphire-on-call-retro`, and `scheduled:security-bounty-rotation`, so that once artsy/cli#331 lands, these workflows can actually opt into sourcing on-call from [Orbit](https://github.com/artsy/orbit) instead of Opsgenie.

## What this does
Each workflow's `Run CLI` step gets three new env vars, alongside the existing `OPSGENIE_API_KEY`/`SLACK_WEB_API_TOKEN`:
- `ORBIT_URL` — shared across all three. Reads `secrets.ORBIT_URL || vars.ORBIT_URL`, so it works whichever store it ends up in.
- `ORBIT_TOKEN` — shared across all three, a credential, so it's a **secret** only.
- one rotation-id **variable** per workflow (`vars.*`, not `secrets.*` — a rotation id isn't sensitive on its own; auth is via `ORBIT_TOKEN`): `ORBIT_SAPPHIRE_ROTATION_ID`, `ORBIT_SAPPHIRE_RETRO_ROTATION_ID`, `ORBIT_SECURITY_BOUNTY_ROTATION_ID`

## Why this is safe to merge even before the values exist
None of these are configured in this repo yet, so today every reference resolves to an empty string. The CLI's Orbit lookup ([artsy/cli#331](https://github.com/artsy/cli/pull/331)) is opt-in and only activates once its rotation-id env var is non-empty — so until the values below are actually added, these workflows keep running exactly as they do today (Opsgenie).

## To actually turn Orbit on (follow-up, not part of this PR)
Someone with repo access needs to add, in GitHub → Settings → Secrets and variables → Actions:
- **Secrets** tab: `ORBIT_TOKEN` (an Orbit read-only service token — see `ORBIT_SERVICE_TOKENS` in Orbit's own config), and optionally `ORBIT_URL` if you'd rather keep it out of the (world-readable-to-repo-collaborators) Variables tab
- **Variables** tab: `ORBIT_URL` (e.g. `https://orbit.artsy.net`, unless placed in Secrets instead) and the relevant rotation id(s) for whichever workflow(s) you want to switch over — found via the Orbit UI, `/rotations/<id>`

You can switch these over independently — e.g. set just `ORBIT_SAPPHIRE_ROTATION_ID` to move that one workflow to Orbit while the other two keep using Opsgenie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKQn1QibQsnUP3CPqPBJ5z